### PR TITLE
Allow retrieval of Keychain Record Attributes

### DIFF
--- a/MobileHost/CodableKeychain.xcodeproj/project.pbxproj
+++ b/MobileHost/CodableKeychain.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				DEVELOPMENT_TEAM = 6D429SHX3Y;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -367,6 +368,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				DEVELOPMENT_TEAM = 6D429SHX3Y;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -385,6 +387,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MobileHost.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6D429SHX3Y;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -403,6 +406,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = MobileHost.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6D429SHX3Y;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Sources/Keychain.swift
+++ b/Sources/Keychain.swift
@@ -121,6 +121,14 @@ public final class Keychain {
     }
 
     private func retrieveAccounts(withService service: String = defaultService, accessGroup: String? = defaultAccessGroup, useDataProtection: Bool) throws -> [String] {
+        return try retrieveRecordAttributes(withService: service, accessGroup: accessGroup, useDataProtection: useDataProtection).compactMap { $0[Constants.account] as? String }
+    }
+    
+    public func retrieveRecordAttributes(withService service: String = defaultService, accessGroup: String? = defaultAccessGroup) throws -> [[String: Any]] {
+        try retrieveRecordAttributes(withService: service, accessGroup: accessGroup, useDataProtection: true)
+    }
+    
+    private func retrieveRecordAttributes(withService service: String = defaultService, accessGroup: String? = defaultAccessGroup, useDataProtection: Bool) throws -> [[String: Any]] {
         var query = self.query(forAccount: nil, service: service, accessGroup: accessGroup, useDataProtection: useDataProtection)
         query[Constants.matchLimit] = Constants.matchLimitAll
         query[Constants.returnAttributes] = kCFBooleanTrue
@@ -129,7 +137,7 @@ public final class Keychain {
         if let error = error(fromStatus: status), error != .itemNotFound { throw error }
         guard result != nil else { return [] }
         guard let attributes = result as? [[String: Any]] else { throw AccessError.invalidAccountRetrievalResult }
-        return attributes.compactMap { $0[Constants.account] as? String }
+        return attributes
     }
 
     public func delete<T: KeychainStorable>(_ storable: T, service: String = defaultService, accessGroup: String? = defaultAccessGroup) throws {


### PR DESCRIPTION
Exposed a new public API allowing host applications to query for a Keychain record's attributes. This is necessary to support dynamically determining the development team id at run time which is required when a binary has been resigned to run in a testing environment.